### PR TITLE
Fix some issues with resolving to single items causing logic to break

### DIFF
--- a/src/patent_client/epo/inpadoc/integration_test.py
+++ b/src/patent_client/epo/inpadoc/integration_test.py
@@ -29,11 +29,13 @@ class TestInpadoc():
         result = Inpadoc.objects.get(publication="WO2009085664A2").biblio
         assert result.abstract is not None 
 
-
     def test_can_index_inpadoc_result(self):
         result = Inpadoc.objects.filter(applicant='Tesla')
         assert result[0] != result[1]
 
+    def test_can_handle_single_item_ipc_classes(self):
+        result = Inpadoc.objects.get(publication="WO2020081771").biblio
+        assert result.ipc_classes is not None
 
 class TestInpadocBiblio():
     def test_inpadoc_biblio_manager(self):

--- a/src/patent_client/util/manager.py
+++ b/src/patent_client/util/manager.py
@@ -36,6 +36,16 @@ def resolve(item, key):
         return None
     return item
 
+def resolve_list(item, key):
+    item_list = resolve(item,key)
+    
+    if item_list is None:
+        return []
+    
+    if isinstance(item_list, list):
+        return item_list
+    
+    return [item_list]
 
 class Manager(Generic[ModelType]):
     """


### PR DESCRIPTION
**Context:**
We're using the library to try and fetch a list of patents using inpadoc.

**Issue:**
In the cases where items were resolved as an OrderedDict instead of a list of OrderedDict objects, the code would fail as it would loop over a list which is actually an OrderedDict.

**Fix:**
Added a resolve_list to the manager which will return a list or an empty list, never None. This way we don't have to add special logic in case the resolving returns None

Updated:

- publications
- ipc_classes
- applications
- applicants
- inventors

These will now always be a list.

I also added an integration test on an item of which I know only contains one item for ipc_classes.
