### PR TITLE
Update the date format to match the new YYYYW week number used by the EPO for legal codes spreadsheet

### DIFF
--- a/src/patent_client/epo/ops/legal/national_codes.py
+++ b/src/patent_client/epo/ops/legal/national_codes.py
@@ -38,7 +38,7 @@ def has_current_spreadsheet():
     try:
         fname = cur.execute("SELECT * FROM meta").fetchone()[0]
         date_string = re.search(r"legal_code_descriptions_(\d+)\.xlsx", fname).group(1)
-        date = datetime.datetime.strptime(date_string, "%Y%m%d").date()
+        date = datetime.datetime.strptime(date_string, "%Y%W").date()
         age = datetime.datetime.now().date() - date
         logger.debug(f"Legal Code Database is {age} days old")
         return age.days <= 30


### PR DESCRIPTION
Update the date format to match the new YYYYW week number used by the EPO for legal codes spreadsheet.