### PR TITLE
Added Inpadoc download and cache control options

### DIFF
--- a/src/patent_client/epo/ops/published/api.py
+++ b/src/patent_client/epo/ops/published/api.py
@@ -111,10 +111,15 @@ class PublishedImagesApi:
         return BytesIO(response.raw.read())
 
     @classmethod
-    def get_page_image_from_link(cls, link, page_number, image_format="pdf"):
+    def get_page_image_from_link(cls, link, page_number, image_format="pdf", no_store=False):
+        user_header = None
+        if no_store == True:
+            user_header = {'Cache-Control':'no-store'}
+                    
         response = session.get(
             f"https://ops.epo.org/3.2/rest-services/{link}.{image_format}",
             params={"Range": page_number},
+            headers=user_header,
             stream=True,
         )
         response.raise_for_status()

--- a/src/patent_client/epo/ops/published/model/images.py
+++ b/src/patent_client/epo/ops/published/model/images.py
@@ -24,13 +24,14 @@ class ImageDocument(Model):
     sections: List[Section] = field(default_factory=list)
     doc_number: str = None
 
-    def download(self, path="."):
+    def download(self, path=".", filename='', extension='.pdf', no_store=False):
         from ..api import PublishedImagesApi
-
-        out_file = Path(path) / f"{self.doc_number}.pdf"
+        if len(filename) == 0:
+            filename = self.doc_number
+        out_file = Path(path) / f"{filename}{extension}"
         writer = PdfWriter()
         for i in range(1, self.num_pages + 1):
-            page_data = PublishedImagesApi.get_page_image_from_link(self.link, page_number=i)
+            page_data = PublishedImagesApi.get_page_image_from_link(self.link, page_number=i, no_store=no_store)
             page = PdfReader(page_data).pages[0]
             if page["/Rotate"] == 90:
                 page.rotate_clockwise(-90)
@@ -41,6 +42,7 @@ class ImageDocument(Model):
 
         with out_file.open("wb") as f:
             writer.write(f)
+        return Path(path) / f"{filename}{extension}"
 
 
 @dataclass

--- a/src/patent_client/uspto/global_dossier/api.py
+++ b/src/patent_client/uspto/global_dossier/api.py
@@ -15,12 +15,16 @@ class GlobalDossierApi:
         response.raise_for_status()
         return response.json()
 
-    def get_document(self, country, doc_number, document_id, out_path):
+    def get_document(self, country, doc_number, document_id, out_path, no_store=False):
         if out_path.exists():
             return out_path
+        
+        user_header = None
+        if no_store == True:
+            user_header = {'Cache-Control':'no-store'}
 
         url = f"https://gd-api2.uspto.gov/doc-content/svc/doccontent/{country}/{doc_number}/{document_id}/1/PDF"
-        response = session.get(url, stream=True)
+        response = session.get(url, headers=user_header, stream=True)
         response.raise_for_status()
         with out_path.open("wb") as f:
             for chunk in response.iter_content(chunk_size=8192):

--- a/src/patent_client/uspto/global_dossier/model.py
+++ b/src/patent_client/uspto/global_dossier/model.py
@@ -134,11 +134,12 @@ class Document(Model):
     doc_group_code: "str" = None
     shareable: "bool" = None
 
-    def download(self, filename="", path="."):
+    def download(self, filename="", path=".", no_store=True):
+        #print(f'IM HERE!!')
         out_path = Path(path).expanduser() / (
             f'{self.date.isoformat()} - {self.doc_desc.replace("/", "_")}.pdf' if not filename else filename
         )
-        return global_dossier_api.get_document(self.country, self.doc_number, self.doc_id, out_path=out_path)
+        return global_dossier_api.get_document(self.country, self.doc_number, self.doc_id, out_path=out_path, no_store=False)
 
 
 @dataclass


### PR DESCRIPTION
I've added a second commit to also add cache toggling to globaldossier downloads.  The same connection disconnect issue is happening, which goes away when cache control is disabled for the download requests.  Appears to be a latency issue.
- Added optional filename and extension parameters to inpadoc download function.  The download function also now returns the path of the file that was downloaded.
- Added optional no_store flag to trigger cache control.  This was to resolve a bug where the response caching logic was causing Inpadoc to close a stream before it was fully read (very weird).  The ultimate fix may be to have caching performed asynchronously from the stream reading to avoid this issue.  Something to consider in the future.

[link](https://ibb.co/SQp3NZY)