### PR TITLE
add page_number parameter to download all pages of pdf files

### DIFF
--- a/patent_client/_sync/uspto/global_dossier/api.py
+++ b/patent_client/_sync/uspto/global_dossier/api.py
@@ -54,6 +54,6 @@ class GlobalDossierApi:
         response.raise_for_status()
         return DocumentList.model_validate_json(response.content)
 
-    def get_document(self, country, doc_number, document_id, out_path):
-        url = f"{self.get_base_url()}/doc-content/svc/doccontent/{country}/{doc_number}/{document_id}/1/PDF"
+    def get_document(self, country, doc_number, document_id, page_number, out_path):
+        url = f"{self.get_base_url()}/doc-content/svc/doccontent/{country}/{doc_number}/{document_id}/{page_number}/PDF"
         return client.download(url, path=out_path)

--- a/patent_client/_sync/uspto/global_dossier/model.py
+++ b/patent_client/_sync/uspto/global_dossier/model.py
@@ -162,7 +162,7 @@ class Document(GlobalDossierBaseModel):
             else filename
         )
         return global_dossier_api.get_document(
-            self.country, self.doc_number, self.doc_id, out_path=out_path
+            self.country, self.doc_number, self.doc_id, self.pages, out_path=out_path
         )
 
 


### PR DESCRIPTION
The problem I'm solving is that you can only download the first page of the pdf documents in the global folder.

I've added a parameter to the global_dossier_api.get_document() method to download all the pages of a PDF file.