### PR TITLE
caching only pages with a status code 200

### DIFF
--- a/patent_client/_async/http_client.py
+++ b/patent_client/_async/http_client.py
@@ -36,7 +36,7 @@ patent_client_transport = hishel.AsyncCacheTransport(
         retries=3,
     ),
     storage=hishel.AsyncFileStorage(base_path=CACHE_DIR),
-    controller=hishel.Controller(allow_heuristics=True),
+    controller=hishel.Controller(allow_heuristics=True, cacheable_status_codes=[200]),
 )
 
 

--- a/patent_client/_sync/http_client.py
+++ b/patent_client/_sync/http_client.py
@@ -42,7 +42,7 @@ patent_client_transport = hishel.CacheTransport(
         retries=3,
     ),
     storage=hishel.FileStorage(base_path=CACHE_DIR),
-    controller=hishel.Controller(allow_heuristics=True),
+    controller=hishel.Controller(allow_heuristics=True, cacheable_status_codes=[200]),
 )
 
 

--- a/patent_client/session.py
+++ b/patent_client/session.py
@@ -36,7 +36,7 @@ patent_client_transport = hishel.AsyncCacheTransport(
         retries=3,
     ),
     storage=hishel.AsyncFileStorage(base_path=CACHE_DIR),
-    controller=hishel.Controller(allow_heuristics=True, key_generator=cache_key_generator),
+    controller=hishel.Controller(allow_heuristics=True, key_generator=cache_key_generator, cacheable_status_codes=[200]),
 )
 
 


### PR DESCRIPTION
Using the global folder service (which is unstable), pages with a 404 error were cached. 
This PR solves the problem by caching only pages with the status 200