### PR TITLE
update config file to include a missing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## 5.0.17 (2024-09-24)
 - Update USPTO ODP to work with ODP versoion 1.0.0
+- Update config file to include a missing dependency
 
 ## 5.0.16 (2024-07-02)
 - Add `document_title` to PTAB model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pypdf = "^4.2.0"
 hishel = "^0.0.26"
 async-property = "^0.2.2"
 httpx = {extras = ["http2"], version = "^0.27.0"}
+urllib3 = ">=1.21.1"
 
 # Documentation Dependencies
 inflection = "^0.5.1"


### PR DESCRIPTION
Assignment Manager relies on urllib3, but it wasn't included as a required dependency in pyproject.toml. This omission led to runtime errors where users encountered exceptions due to urllib3 being missing. This commit adds urllib3 to pyproject.toml, resolving the issue.