### PR TITLE
Add return type to pydantic computed field decorator

### DIFF
--- a/patent_client/_async/uspto/peds/model.py
+++ b/patent_client/_async/uspto/peds/model.py
@@ -435,7 +435,7 @@ class Document(PEDSBaseModel):
         out_path = await client.download(full_url, path=path)
         return out_path
 
-    @computed_field
+    @computed_field(return_type=str)
     @async_property
     async def application(self) -> USApplication:
         return await self._get_model(".USApplication").objects.get(


### PR DESCRIPTION
following error suggestion:

PydanticUserError: Computed field is missing return type annotation or specifying return_type to the @computed_field decorator (e.g. @computed_field(return_type=int | str))

